### PR TITLE
Add configuration option for TAP mode

### DIFF
--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -205,14 +205,14 @@ func (c *Core) DEBUG_getAddr() *address {
 	return address_addrForNodeID(&c.dht.nodeID)
 }
 
-func (c *Core) DEBUG_startTun(ifname string) {
-	c.DEBUG_startTunWithMTU(ifname, 1280)
+func (c *Core) DEBUG_startTun(ifname string, iftapmode bool) {
+	c.DEBUG_startTunWithMTU(ifname, iftapmode, 1280)
 }
 
-func (c *Core) DEBUG_startTunWithMTU(ifname string, mtu int) {
+func (c *Core) DEBUG_startTunWithMTU(ifname string, iftapmode bool, mtu int) {
 	addr := c.DEBUG_getAddr()
 	straddr := fmt.Sprintf("%s/%v", net.IP(addr[:]).String(), 8*len(address_prefix))
-	err := c.tun.setup(ifname, straddr, mtu)
+	err := c.tun.setup(ifname, iftapmode, straddr, mtu)
 	if err != nil {
 		panic(err)
 	}

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -10,7 +10,10 @@ import "golang.org/x/sys/unix"
 
 import water "github.com/songgao/water"
 
-func (tun *tunDevice) setup(ifname string, addr string, mtu int) error {
+func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
+	if iftapmode {
+		tun.core.log.Printf("TAP mode is not supported on this platform, defaulting to TUN")
+	}
 	config := water.Config{DeviceType: water.TUN}
 	iface, err := water.New(config)
 	if err != nil {

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -9,8 +9,13 @@ import "strings"
 
 import water "github.com/songgao/water"
 
-func (tun *tunDevice) setup(ifname string, addr string, mtu int) error {
-	config := water.Config{DeviceType: water.TUN}
+func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
+	var config water.Config
+	if iftapmode {
+		config = water.Config{DeviceType: water.TAP}
+	} else {
+		config = water.Config{DeviceType: water.TUN}
+	}
 	if ifname != "" && ifname != "auto" {
 		config.Name = ifname
 	}

--- a/src/yggdrasil/tun_other.go
+++ b/src/yggdrasil/tun_other.go
@@ -9,8 +9,13 @@ import water "github.com/songgao/water"
 // This is to catch unsupported platforms
 // If your platform supports tun devices, you could try configuring it manually
 
-func (tun *tunDevice) setup(ifname string, addr string, mtu int) error {
-	config := water.Config{DeviceType: water.TUN}
+func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
+	var config water.Config
+	if iftapmode {
+		config = water.Config{DeviceType: water.TAP}
+	} else {
+		config = water.Config{DeviceType: water.TUN}
+	}
 	iface, err := water.New(config)
 	if err != nil {
 		panic(err)

--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -7,7 +7,10 @@ import "fmt"
 
 // This is to catch Windows platforms
 
-func (tun *tunDevice) setup(ifname string, addr string, mtu int) error {
+func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
+	if !iftapmode {
+		tun.core.log.Printf("TUN mode is not supported on this platform, defaulting to TAP")
+	}
 	config := water.Config{DeviceType: water.TAP}
 	config.PlatformSpecificParams.ComponentID = "tap0901"
 	config.PlatformSpecificParams.Network = "169.254.0.1/32"

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -39,6 +39,7 @@ type nodeConfig struct {
 	Multicast   bool
 	LinkLocal   string
 	IfName      string
+	IfTAPMode   bool
 }
 
 type node struct {
@@ -104,7 +105,7 @@ func generateConfig() *nodeConfig {
 	spub, spriv := core.DEBUG_newSigKeys()
 	cfg := nodeConfig{}
 	cfg.Listen = "[::]:0"
-	cfg.AdminListen = "localhost:9001"
+	cfg.AdminListen = "[::1]:9001"
 	cfg.BoxPub = hex.EncodeToString(bpub[:])
 	cfg.BoxPriv = hex.EncodeToString(bpriv[:])
 	cfg.SigPub = hex.EncodeToString(spub[:])
@@ -113,6 +114,11 @@ func generateConfig() *nodeConfig {
 	cfg.Multicast = true
 	cfg.LinkLocal = ""
 	cfg.IfName = "auto"
+	if runtime.GOOS == "windows" {
+		cfg.IfTAPMode = true
+	} else {
+		cfg.IfTAPMode = false
+	}
 	return &cfg
 }
 
@@ -258,7 +264,7 @@ func main() {
 	n.init(cfg, logger)
 	logger.Println("Starting tun...")
 	//n.core.DEBUG_startTun(cfg.IfName) // 1280, the smallest supported MTU
-	n.core.DEBUG_startTunWithMTU(cfg.IfName, 65535) // Largest supported MTU
+	n.core.DEBUG_startTunWithMTU(cfg.IfName, cfg.IfTAPMode, 65535) // Largest supported MTU
 	defer func() {
 		logger.Println("Closing...")
 		n.core.DEBUG_stopTun()


### PR DESCRIPTION
Adds the `IfTAPMode` configuration option, which allows selecting TAP mode over TUN mode on supported platforms like Linux.

This option will be ignored on macOS or Windows, as macOS only supports TUN mode with `utun` and Windows with the OpenVPN TAP driver only supports TAP mode. 

Right now there is a problem when selecting TAP mode on Linux and then configuring an MTU larger than `65521` (`65535-14` for the Ethernet headers). A smaller MTU might be required to get around this.