### PR TITLE
Include endpoint MTU in session pings

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -223,6 +223,7 @@ func (a *admin) getData_getSessions() []admin_nodeInfo {
 			info := admin_nodeInfo{
 				{"IP", net.IP(sinfo.theirAddr[:]).String()},
 				{"coords", fmt.Sprint(sinfo.coords)},
+				{"MTU", fmt.Sprint(sinfo.getMTU())},
 			}
 			infos = append(infos, info)
 		}

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -145,6 +145,10 @@ func (r *router) sendPacket(bs []byte) {
 		fallthrough
 	//default: go func() { sinfo.send<-bs }()
 	default:
+		if len(bs) > int(sinfo.getMTU()) {
+			// TODO: Send ICMPv6 Packet Too Big back to the TUN/TAP adapter
+			sinfo.core.log.Printf("Packet length %d exceeds session MTU %d", len(bs), sinfo.getMTU())
+		}
 		select {
 		case sinfo.send <- bs:
 		default:

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -5,7 +5,6 @@ package yggdrasil
 // The session information consists of crypto keys and coords
 
 import "time"
-import "net"
 
 type sessionInfo struct {
 	core         *Core
@@ -60,7 +59,6 @@ func (s *sessionInfo) update(p *sessionPing) bool {
 		s.theirNonce = boxNonce{}
 		s.nonceMask = 0
 	}
-	s.core.log.Printf("Received MTU %d from %s", p.mtu, net.IP(s.theirAddr[:]).String())
 	if p.mtu >= 1280 {
 		s.theirMTU = p.mtu
 	}
@@ -205,7 +203,6 @@ func (sinfo *sessionInfo) close() {
 func (ss *sessions) getPing(sinfo *sessionInfo) sessionPing {
 	loc := ss.core.switchTable.getLocator()
 	coords := loc.getCoords()
-	sinfo.core.log.Printf("Sending MTU %d to %s", sinfo.myMTU, net.IP(sinfo.theirAddr[:]).String())
 	ref := sessionPing{
 		sendPermPub: ss.core.boxPub,
 		handle:      sinfo.myHandle,

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -429,12 +429,14 @@ func (p *sessionPing) encode() []byte {
 	bs = append(bs, wire_encode_uint64(wire_intToUint(p.tstamp))...)
 	coords := wire_encode_coords(p.coords)
 	bs = append(bs, coords...)
+	bs = append(bs, wire_encode_uint64(uint64(p.mtu))...)
 	return bs
 }
 
 func (p *sessionPing) decode(bs []byte) bool {
 	var pType uint64
 	var tstamp uint64
+	var mtu uint64
 	switch {
 	case !wire_chop_uint64(&pType, &bs):
 		return false
@@ -449,11 +451,14 @@ func (p *sessionPing) decode(bs []byte) bool {
 		return false
 	case !wire_chop_coords(&p.coords, &bs):
 		return false
+	case !wire_chop_uint64(&mtu, &bs):
+		mtu = 1280
 	}
 	p.tstamp = wire_intFromUint(tstamp)
 	if pType == wire_SessionPong {
 		p.isPong = true
 	}
+	p.mtu = uint16(mtu)
 	return true
 }
 

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -40,6 +40,7 @@ type nodeConfig struct {
 	LinkLocal   string
 	IfName      string
 	IfTAPMode   bool
+	IfMTU       int
 }
 
 type node struct {
@@ -114,6 +115,7 @@ func generateConfig() *nodeConfig {
 	cfg.Multicast = true
 	cfg.LinkLocal = ""
 	cfg.IfName = "auto"
+	cfg.IfMTU = 65535
 	if runtime.GOOS == "windows" {
 		cfg.IfTAPMode = true
 	} else {
@@ -264,7 +266,7 @@ func main() {
 	n.init(cfg, logger)
 	logger.Println("Starting tun...")
 	//n.core.DEBUG_startTun(cfg.IfName) // 1280, the smallest supported MTU
-	n.core.DEBUG_startTunWithMTU(cfg.IfName, cfg.IfTAPMode, 65535) // Largest supported MTU
+	n.core.DEBUG_startTunWithMTU(cfg.IfName, cfg.IfTAPMode, cfg.IfMTU) // Largest supported MTU
 	defer func() {
 		logger.Println("Closing...")
 		n.core.DEBUG_stopTun()


### PR DESCRIPTION
Extends the session pings to include the MTU of each endpoint. The `sessionInfo.getMTU()` function returns the lowest of the two MTUs. In the event that a node does not report an MTU, or tries to report an MTU smaller than the IPv6 minimum MTU size (1280), it is assumed to be 1280 (to be as "backward-compatible" as possible).

Now that the session MTU is known, it can be used for:

- Ensuring we are not sending oversized packets when using UDP
- Possible MSS clamping or window size tuning with TCP
- Ensuring that we are not writing bigger packets to the TUN/TAP than the operating system expects

It makes sense that the MTU should be configurable to the user, not least because we cannot make assumptions about networks, people may want to bridge the TAP adapter with links of a smaller MTU, etc. Perhaps another configuration option to be added, seeing as Water seemingly doesn't implement an intelligent way to retrieve the actual active MTU from the TUN adapter itself.