### PR TITLE
Allow setting IfName to 'none' to run without TUN/TAP

### DIFF
--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -212,11 +212,13 @@ func (c *Core) DEBUG_startTun(ifname string, iftapmode bool) {
 func (c *Core) DEBUG_startTunWithMTU(ifname string, iftapmode bool, mtu int) {
 	addr := c.DEBUG_getAddr()
 	straddr := fmt.Sprintf("%s/%v", net.IP(addr[:]).String(), 8*len(address_prefix))
-	err := c.tun.setup(ifname, iftapmode, straddr, mtu)
-	if err != nil {
-		panic(err)
+	if ifname != "none" {
+		err := c.tun.setup(ifname, iftapmode, straddr, mtu)
+		if err != nil {
+			panic(err)
+		}
+		go c.tun.read()
 	}
-	go c.tun.read()
 	go c.tun.write()
 }
 

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -33,6 +33,9 @@ func (tun *tunDevice) init(core *Core) {
 func (tun *tunDevice) write() error {
 	for {
 		data := <-tun.recv
+		if tun.iface == nil {
+			continue
+		}
 		if tun.iface.IsTAP() {
 			var frame ethernet.Frame
 			frame.Prepare(
@@ -88,5 +91,8 @@ func (tun *tunDevice) read() error {
 }
 
 func (tun *tunDevice) close() error {
+	if tun.iface == nil {
+		return nil
+	}
 	return tun.iface.Close()
 }

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -264,7 +264,11 @@ func main() {
 	logger.Println("Initializing...")
 	n := node{}
 	n.init(cfg, logger)
-	logger.Println("Starting tun...")
+	if cfg.IfName != "none" {
+		logger.Println("Starting TUN/TAP...")
+	} else {
+		logger.Println("Not starting TUN/TAP")
+	}
 	//n.core.DEBUG_startTun(cfg.IfName) // 1280, the smallest supported MTU
 	n.core.DEBUG_startTunWithMTU(cfg.IfName, cfg.IfTAPMode, cfg.IfMTU) // Largest supported MTU
 	defer func() {


### PR DESCRIPTION
Allows Yggdrasil to run without opening a TUN/TAP adapter when `IfName` is set to `none`. Other functions (i.e. peer routing/switching) continue to run normally.