### PR TITLE
Add a rumor mill to throttle dht maintenance traffic

### DIFF
--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -26,6 +26,7 @@ func (n *Node) init(index int) {
 	n.core.Init()
 	n.send = n.core.DEBUG_getSend()
 	n.recv = n.core.DEBUG_getRecv()
+	n.core.DEBUG_simFixMTU()
 }
 
 func (n *Node) printTraffic() {
@@ -424,7 +425,19 @@ func main() {
 	  }
 	*/
 	startNetwork(kstore)
-	if true {
+	//time.Sleep(10*time.Second)
+	// Note that testPaths only works if pressure is turend off
+	//  Otherwise congestion can lead to routing loops?
+	for finished := false; !finished; {
+		finished = testPaths(kstore)
+	}
+	pingNodes(kstore)
+	//pingBench(kstore) // Only after disabling debug output
+	//stressTest(kstore)
+	//time.Sleep(120*time.Second)
+	dumpDHTSize(kstore) // note that this uses racey functions to read things...
+	if false {
+		// This connects the sim to the local network
 		for _, node := range kstore {
 			node.startUDP("localhost:0")
 			node.connectUDP("localhost:12345")
@@ -440,15 +453,4 @@ func main() {
 		var block chan struct{}
 		<-block
 	}
-	//time.Sleep(10*time.Second)
-	// Note that testPaths only works if pressure is turend off
-	//  Otherwise congestion can lead to routing loops?
-	for finished := false; !finished; {
-		finished = testPaths(kstore)
-	}
-	pingNodes(kstore)
-	//pingBench(kstore) // Only after disabling debug output
-	//stressTest(kstore)
-	//time.Sleep(120*time.Second)
-	dumpDHTSize(kstore) // note that this uses racey functions to read things...
 }

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -369,3 +369,7 @@ func DEBUG_simLinkPeers(p, q *peer) {
 	go p.linkLoop(plinkIn)
 	go q.linkLoop(qlinkIn)
 }
+
+func (c *Core) DEBUG_simFixMTU() {
+	c.tun.mtu = 65535
+}


### PR DESCRIPTION
Like the title says. There's a DHT maintenance cycle once per second. Previously, each maintenance cycle, the DHT would send two pings. The first was sent to the least recently pinged node (ignoring nodes pinged in the last few seconds, to give them a chance to respond), and the second would cycle through buckets and ping a node from top of the bucket, with a target selected to help fill any holes / bootstrap the DHT. When a node responds to a DHT lookup, up to 2 nodes from the response would immediately be pinged (with their own address as the target, and any nodes in the response are ignored to prevent infinite loops of spam).

The rumor mill does basically the same thing, but instead of pinging nodes, it adds them to a rumor mill. Then, once per second (as the last step of the maintenance cycle), the oldest node in a non-empty mill is removed from the mill and pinged with the appropriate target.

The result is that, instead of the DHT using up to 6 pings per second (2 initial, 2x2 response), with some variation based on if there's a response, it should now consistently use 1 per second. This causes the DHT to converge more slowly after a coordinate change (it pings nodes less often, so it takes longer to notice that a node has timed out and remove it). so the timing may need to be adjusted to compensate--but the timing is arbitrary to begin with, so further study is needed.