### PR TITLE
Catch SIGTERM and Windows service termination

### DIFF
--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -9,6 +9,7 @@ import "io/ioutil"
 import "net"
 import "os"
 import "os/signal"
+import "syscall"
 import "time"
 import "regexp"
 
@@ -21,7 +22,7 @@ import "golang.org/x/net/ipv6"
 
 import . "yggdrasil"
 
-import _ "github.com/kardianos/minwinsvc"
+import "github.com/kardianos/minwinsvc"
 
 /**
 * This is a very crude wrapper around src/yggdrasil
@@ -306,7 +307,13 @@ func main() {
 	}
 	// Catch interrupt to exit gracefully
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, os.Kill)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	// Create a function to capture the service being stopped on Windows
+	winTerminate := func() {
+  	c <- os.Interrupt
+  }
+	minwinsvc.SetOnExit(winTerminate)
+	// Wait for the terminate/interrupt signal
 	<-c
 	logger.Println("Stopping...")
 }

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -310,8 +310,8 @@ func main() {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	// Create a function to capture the service being stopped on Windows
 	winTerminate := func() {
-  	c <- os.Interrupt
-  }
+		c <- os.Interrupt
+	}
 	minwinsvc.SetOnExit(winTerminate)
 	// Wait for the terminate/interrupt signal
 	<-c


### PR DESCRIPTION
Adds `SIGTERM` to the list of captured OS signals and removes `SIGKILL` which is impossible to catch.

Also adds a function to handle the Yggdrasil service being terminated on Windows.