### PR TITLE
Breaking wire format cleanup and other updates

### DIFF
--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -127,7 +127,7 @@ func (ps *peers) newPeer(box *boxPubKey,
 func (p *peer) linkLoop(in <-chan []byte) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	p.lastSend = time.Now()
+	var counter uint8
 	var lastRSeq uint64
 	for {
 		select {
@@ -151,7 +151,7 @@ func (p *peer) linkLoop(in <-chan []byte) {
 					update = true
 				case p.msgAnc.rseq != p.myMsg.seq:
 					update = true
-				case time.Since(p.lastSend) > 3*time.Second:
+				case counter%4 == 0:
 					update = true
 				}
 				if update {
@@ -161,6 +161,7 @@ func (p *peer) linkLoop(in <-chan []byte) {
 					p.lastSend = time.Now()
 					p.sendSwitchAnnounce()
 				}
+				counter = (counter + 1) % 4
 			}
 		}
 	}

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -223,8 +223,6 @@ func (p *peer) sendPacket(packet []byte) {
 func (p *peer) sendLinkPacket(packet []byte) {
 	bs, nonce := boxSeal(&p.shared, packet, nil)
 	linkPacket := wire_linkProtoTrafficPacket{
-		//toKey:   p.box,
-		//fromKey: p.core.boxPub,
 		nonce:   *nonce,
 		payload: bs,
 	}
@@ -237,12 +235,6 @@ func (p *peer) handleLinkTraffic(bs []byte) {
 	if !packet.decode(bs) {
 		return
 	}
-	//if packet.toKey != p.core.boxPub {
-	//	return
-	//}
-	//if packet.fromKey != p.box {
-	//	return
-	//}
 	payload, isOK := boxOpen(&p.shared, packet.payload, &packet.nonce)
 	if !isOK {
 		return

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -204,8 +204,8 @@ func (p *peer) sendPacket(packet []byte) {
 func (p *peer) sendLinkPacket(packet []byte) {
 	bs, nonce := boxSeal(&p.shared, packet, nil)
 	linkPacket := wire_linkProtoTrafficPacket{
-		toKey:   p.box,
-		fromKey: p.core.boxPub,
+		//toKey:   p.box,
+		//fromKey: p.core.boxPub,
 		nonce:   *nonce,
 		payload: bs,
 	}
@@ -218,12 +218,12 @@ func (p *peer) handleLinkTraffic(bs []byte) {
 	if !packet.decode(bs) {
 		return
 	}
-	if packet.toKey != p.core.boxPub {
-		return
-	}
-	if packet.fromKey != p.box {
-		return
-	}
+	//if packet.toKey != p.core.boxPub {
+	//	return
+	//}
+	//if packet.fromKey != p.box {
+	//	return
+	//}
 	payload, isOK := boxOpen(&p.shared, packet.payload, &packet.nonce)
 	if !isOK {
 		return

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -73,7 +73,6 @@ type peer struct {
 	//  Specifically, processing switch messages, signing, and verifying sigs
 	//  Resets at the start of each tick
 	throttle uint8
-	lastSend time.Time // To throttle sends, use only from linkLoop goroutine
 }
 
 const peer_Throttle = 1
@@ -158,7 +157,6 @@ func (p *peer) linkLoop(in <-chan []byte) {
 					if p.msgAnc != nil {
 						lastRSeq = p.msgAnc.seq
 					}
-					p.lastSend = time.Now()
 					p.sendSwitchAnnounce()
 				}
 				counter = (counter + 1) % 4

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -295,9 +295,10 @@ func (r *router) handleDHTReq(bs []byte, fromKey *boxPubKey) {
 	if !req.decode(bs) {
 		return
 	}
-	if req.key != *fromKey {
-		return
-	}
+	//if req.key != *fromKey {
+	//	return
+	//}
+	req.key = *fromKey
 	r.core.dht.handleReq(&req)
 }
 
@@ -306,9 +307,10 @@ func (r *router) handleDHTRes(bs []byte, fromKey *boxPubKey) {
 	if !res.decode(bs) {
 		return
 	}
-	if res.key != *fromKey {
-		return
-	}
+	//if res.key != *fromKey {
+	//	return
+	//}
+	res.key = *fromKey
 	r.core.dht.handleRes(&res)
 }
 

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -295,9 +295,6 @@ func (r *router) handleDHTReq(bs []byte, fromKey *boxPubKey) {
 	if !req.decode(bs) {
 		return
 	}
-	//if req.key != *fromKey {
-	//	return
-	//}
 	req.key = *fromKey
 	r.core.dht.handleReq(&req)
 }
@@ -307,9 +304,6 @@ func (r *router) handleDHTRes(bs []byte, fromKey *boxPubKey) {
 	if !res.decode(bs) {
 		return
 	}
-	//if res.key != *fromKey {
-	//	return
-	//}
 	res.key = *fromKey
 	r.core.dht.handleRes(&res)
 }

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -390,6 +390,9 @@ func (t *switchTable) updateTable() {
 	}
 	for _, pinfo := range t.data.peers {
 		//if !pinfo.forward { continue }
+		if pinfo.locator.root != newTable.self.root {
+			continue
+		}
 		loc := pinfo.locator.clone()
 		loc.coords = loc.coords[:len(loc.coords)-1] // Remove the them->self link
 		newTable.elems = append(newTable.elems, tableElem{
@@ -422,9 +425,6 @@ func (t *switchTable) lookup(dest []byte, ttl uint64) (switchPort, uint64) {
 	// score is in units of bandwidth / distance
 	bestScore := float64(-1)
 	for _, info := range table.elems {
-		if info.locator.root != table.self.root {
-			continue
-		}
 		dist := info.locator.dist(dest) //getDist(info.locator.coords)
 		if !(dist < myDist) {
 			continue

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -11,11 +11,6 @@ package yggdrasil
 // TODO? use a pre-computed lookup table (python version had this)
 //  A little annoying to do with constant changes from bandwidth estimates
 
-// FIXME (!) throttle how often root updates are accepted
-//  If the root starts spaming with new timestamps, it should only affect their neighbors
-//  The rest of the network should see announcements at a somewhat reasonable rate
-//  Maybe no faster than 2x the usual update interval
-
 import "time"
 import "sync"
 import "sync/atomic"
@@ -23,6 +18,8 @@ import "sync/atomic"
 //import "fmt"
 
 const switch_timeout = time.Minute
+const switch_updateInterval = switch_timeout / 2
+const switch_throttle = switch_updateInterval / 2
 
 // You should be able to provide crypto signatures for this
 // 1 signature per coord, from the *sender* to that coord
@@ -219,7 +216,7 @@ func (t *switchTable) cleanRoot() {
 	}
 	// Or, if we are the root, possibly update our timestamp
 	if t.data.locator.root == t.key &&
-		now.Sub(t.time) > switch_timeout/2 {
+		now.Sub(t.time) > switch_updateInterval {
 		//fmt.Println("root is self and old, updating", t.data.locator.Root)
 		doUpdate = true
 	}
@@ -343,9 +340,11 @@ func (t *switchTable) handleMessage(msg *switchMessage, fromPort switchPort, sig
 		updateRoot = true
 	case cost < pCost:
 		updateRoot = true
-	case sender.port == t.parent &&
-		(msg.locator.tstamp > t.data.locator.tstamp ||
-			!equiv(&msg.locator, &t.data.locator)):
+	case sender.port != t.parent: // do nothing
+	case !equiv(&msg.locator, &t.data.locator):
+		updateRoot = true
+	case now.Sub(t.time) < switch_throttle: // do nothing
+	case msg.locator.tstamp > t.data.locator.tstamp:
 		updateRoot = true
 	}
 	if updateRoot {

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -164,7 +164,7 @@ func (iface *tcpInterface) handler(sock *net.TCPConn) {
 	}
 	out := make(chan []byte, 32) // TODO? what size makes sense
 	defer close(out)
-	buf := bufio.NewWriterSize(sock, 65535)
+	buf := bufio.NewWriterSize(sock, tcp_msgSize)
 	send := func(msg []byte) {
 		msgLen := wire_encode_uint64(uint64(len(msg)))
 		before := buf.Buffered()

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -129,7 +129,7 @@ type msgAnnounce struct {
 	seq    uint64
 	len    uint64
 	//Deg uint64
-	//RSeq uint64
+	rseq uint64
 }
 
 func (m *msgAnnounce) encode() []byte {
@@ -139,7 +139,7 @@ func (m *msgAnnounce) encode() []byte {
 	bs = append(bs, wire_encode_uint64(m.seq)...)
 	bs = append(bs, wire_encode_uint64(m.len)...)
 	//bs = append(bs, wire_encode_uint64(m.Deg)...)
-	//bs = append(bs, wire_encode_uint64(m.RSeq)...)
+	bs = append(bs, wire_encode_uint64(m.rseq)...)
 	return bs
 }
 
@@ -159,8 +159,9 @@ func (m *msgAnnounce) decode(bs []byte) bool {
 		return false
 	case !wire_chop_uint64(&m.len, &bs):
 		return false
-		//case !wire_chop_uint64(&m.Deg, &bs): return false
-		//case !wire_chop_uint64(&m.RSeq, &bs): return false
+	//case !wire_chop_uint64(&m.Deg, &bs): return false
+	case !wire_chop_uint64(&m.rseq, &bs):
+		return false
 	}
 	m.tstamp = wire_intFromUint(tstamp)
 	return true
@@ -467,7 +468,7 @@ func (p *sessionPing) decode(bs []byte) bool {
 func (r *dhtReq) encode() []byte {
 	coords := wire_encode_coords(r.coords)
 	bs := wire_encode_uint64(wire_DHTLookupRequest)
-	bs = append(bs, r.key[:]...)
+	//bs = append(bs, r.key[:]...)
 	bs = append(bs, coords...)
 	bs = append(bs, r.dest[:]...)
 	return bs
@@ -480,8 +481,8 @@ func (r *dhtReq) decode(bs []byte) bool {
 		return false
 	case pType != wire_DHTLookupRequest:
 		return false
-	case !wire_chop_slice(r.key[:], &bs):
-		return false
+	//case !wire_chop_slice(r.key[:], &bs):
+	//	return false
 	case !wire_chop_coords(&r.coords, &bs):
 		return false
 	case !wire_chop_slice(r.dest[:], &bs):
@@ -494,7 +495,7 @@ func (r *dhtReq) decode(bs []byte) bool {
 func (r *dhtRes) encode() []byte {
 	coords := wire_encode_coords(r.coords)
 	bs := wire_encode_uint64(wire_DHTLookupResponse)
-	bs = append(bs, r.key[:]...)
+	//bs = append(bs, r.key[:]...)
 	bs = append(bs, coords...)
 	bs = append(bs, r.dest[:]...)
 	for _, info := range r.infos {
@@ -512,8 +513,8 @@ func (r *dhtRes) decode(bs []byte) bool {
 		return false
 	case pType != wire_DHTLookupResponse:
 		return false
-	case !wire_chop_slice(r.key[:], &bs):
-		return false
+	//case !wire_chop_slice(r.key[:], &bs):
+	//	return false
 	case !wire_chop_coords(&r.coords, &bs):
 		return false
 	case !wire_chop_slice(r.dest[:], &bs):

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -21,7 +21,7 @@ const (
 	wire_DHTLookupResponse          // inside protocol traffic header
 	wire_SearchRequest              // inside protocol traffic header
 	wire_SearchResponse             // inside protocol traffic header
-	//wire_Keys                 // udp key packet (boxPub, sigPub)
+	wire_Keys                       // udp key packet (boxPub, sigPub)
 )
 
 // Encode uint64 using a variable length scheme

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -380,16 +380,16 @@ func (p *wire_protoTrafficPacket) decode(bs []byte) bool {
 }
 
 type wire_linkProtoTrafficPacket struct {
-	toKey   boxPubKey
-	fromKey boxPubKey
+	//toKey   boxPubKey
+	//fromKey boxPubKey
 	nonce   boxNonce
 	payload []byte
 }
 
 func (p *wire_linkProtoTrafficPacket) encode() []byte {
 	bs := wire_encode_uint64(wire_LinkProtocolTraffic)
-	bs = append(bs, p.toKey[:]...)
-	bs = append(bs, p.fromKey[:]...)
+	//bs = append(bs, p.toKey[:]...)
+	//bs = append(bs, p.fromKey[:]...)
 	bs = append(bs, p.nonce[:]...)
 	bs = append(bs, p.payload...)
 	return bs
@@ -402,10 +402,10 @@ func (p *wire_linkProtoTrafficPacket) decode(bs []byte) bool {
 		return false
 	case pType != wire_LinkProtocolTraffic:
 		return false
-	case !wire_chop_slice(p.toKey[:], &bs):
-		return false
-	case !wire_chop_slice(p.fromKey[:], &bs):
-		return false
+	//case !wire_chop_slice(p.toKey[:], &bs):
+	//	return false
+	//case !wire_chop_slice(p.fromKey[:], &bs):
+	//	return false
 	case !wire_chop_slice(p.nonce[:], &bs):
 		return false
 	}

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -21,7 +21,6 @@ const (
 	wire_DHTLookupResponse          // inside protocol traffic header
 	wire_SearchRequest              // inside protocol traffic header
 	wire_SearchResponse             // inside protocol traffic header
-	wire_Keys                       // udp key packet (boxPub, sigPub)
 )
 
 // Encode uint64 using a variable length scheme
@@ -112,8 +111,6 @@ func wire_put_coords(coords []byte, bs []byte) []byte {
 func wire_decode_coords(packet []byte) ([]byte, int) {
 	coordLen, coordBegin := wire_decode_uint64(packet)
 	coordEnd := coordBegin + int(coordLen)
-	//if coordBegin == 0 { panic("No coords found") } // Testing
-	//if coordEnd > len(packet) { panic("Packet too short") } // Testing
 	if coordBegin == 0 || coordEnd > len(packet) {
 		return nil, 0
 	}
@@ -138,7 +135,6 @@ func (m *msgAnnounce) encode() []byte {
 	bs = append(bs, wire_encode_uint64(wire_intToUint(m.tstamp))...)
 	bs = append(bs, wire_encode_uint64(m.seq)...)
 	bs = append(bs, wire_encode_uint64(m.len)...)
-	//bs = append(bs, wire_encode_uint64(m.Deg)...)
 	bs = append(bs, wire_encode_uint64(m.rseq)...)
 	return bs
 }
@@ -159,7 +155,6 @@ func (m *msgAnnounce) decode(bs []byte) bool {
 		return false
 	case !wire_chop_uint64(&m.len, &bs):
 		return false
-	//case !wire_chop_uint64(&m.Deg, &bs): return false
 	case !wire_chop_uint64(&m.rseq, &bs):
 		return false
 	}
@@ -381,16 +376,12 @@ func (p *wire_protoTrafficPacket) decode(bs []byte) bool {
 }
 
 type wire_linkProtoTrafficPacket struct {
-	//toKey   boxPubKey
-	//fromKey boxPubKey
 	nonce   boxNonce
 	payload []byte
 }
 
 func (p *wire_linkProtoTrafficPacket) encode() []byte {
 	bs := wire_encode_uint64(wire_LinkProtocolTraffic)
-	//bs = append(bs, p.toKey[:]...)
-	//bs = append(bs, p.fromKey[:]...)
 	bs = append(bs, p.nonce[:]...)
 	bs = append(bs, p.payload...)
 	return bs
@@ -403,10 +394,6 @@ func (p *wire_linkProtoTrafficPacket) decode(bs []byte) bool {
 		return false
 	case pType != wire_LinkProtocolTraffic:
 		return false
-	//case !wire_chop_slice(p.toKey[:], &bs):
-	//	return false
-	//case !wire_chop_slice(p.fromKey[:], &bs):
-	//	return false
 	case !wire_chop_slice(p.nonce[:], &bs):
 		return false
 	}
@@ -468,7 +455,6 @@ func (p *sessionPing) decode(bs []byte) bool {
 func (r *dhtReq) encode() []byte {
 	coords := wire_encode_coords(r.coords)
 	bs := wire_encode_uint64(wire_DHTLookupRequest)
-	//bs = append(bs, r.key[:]...)
 	bs = append(bs, coords...)
 	bs = append(bs, r.dest[:]...)
 	return bs
@@ -481,8 +467,6 @@ func (r *dhtReq) decode(bs []byte) bool {
 		return false
 	case pType != wire_DHTLookupRequest:
 		return false
-	//case !wire_chop_slice(r.key[:], &bs):
-	//	return false
 	case !wire_chop_coords(&r.coords, &bs):
 		return false
 	case !wire_chop_slice(r.dest[:], &bs):
@@ -495,7 +479,6 @@ func (r *dhtReq) decode(bs []byte) bool {
 func (r *dhtRes) encode() []byte {
 	coords := wire_encode_coords(r.coords)
 	bs := wire_encode_uint64(wire_DHTLookupResponse)
-	//bs = append(bs, r.key[:]...)
 	bs = append(bs, coords...)
 	bs = append(bs, r.dest[:]...)
 	for _, info := range r.infos {
@@ -513,8 +496,6 @@ func (r *dhtRes) decode(bs []byte) bool {
 		return false
 	case pType != wire_DHTLookupResponse:
 		return false
-	//case !wire_chop_slice(r.key[:], &bs):
-	//	return false
 	case !wire_chop_coords(&r.coords, &bs):
 		return false
 	case !wire_chop_slice(r.dest[:], &bs):

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -177,7 +177,7 @@ func (n *node) listen() {
 		saddr := addr.String()
 		//if _, isIn := n.peers[saddr]; isIn { continue }
 		//n.peers[saddr] = struct{}{}
-		n.core.DEBUG_addTCPConn(saddr) // FIXME? can result in 2 connections per peer
+		n.core.DEBUG_maybeSendUDPKeys(saddr) // FIXME? can result in 2 connections per peer
 		//fmt.Println("DEBUG:", "added multicast peer:", saddr)
 	}
 }
@@ -188,8 +188,8 @@ func (n *node) announce() {
 		panic(err)
 	}
 	var anAddr net.TCPAddr
-	tcpAddr := n.core.DEBUG_getGlobalTCPAddr()
-	anAddr.Port = tcpAddr.Port
+	myAddr := n.core.DEBUG_getGlobalUDPAddr()
+	anAddr.Port = myAddr.Port
 	destAddr, err := net.ResolveUDPAddr("udp6", multicastAddr)
 	if err != nil {
 		panic(err)

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -118,7 +118,7 @@ func generateConfig() *nodeConfig {
 	cfg.Multicast = true
 	cfg.LinkLocal = ""
 	cfg.IfName = "auto"
-	cfg.IfMTU = 65535
+	cfg.IfMTU = 1280 //65535
 	if runtime.GOOS == "windows" {
 		cfg.IfTAPMode = true
 	} else {
@@ -177,7 +177,7 @@ func (n *node) listen() {
 		saddr := addr.String()
 		//if _, isIn := n.peers[saddr]; isIn { continue }
 		//n.peers[saddr] = struct{}{}
-		n.core.DEBUG_maybeSendUDPKeys(saddr) // FIXME? can result in 2 connections per peer
+		n.core.DEBUG_addTCPConn(saddr) // FIXME? can result in 2 connections per peer
 		//fmt.Println("DEBUG:", "added multicast peer:", saddr)
 	}
 }
@@ -188,7 +188,7 @@ func (n *node) announce() {
 		panic(err)
 	}
 	var anAddr net.TCPAddr
-	myAddr := n.core.DEBUG_getGlobalUDPAddr()
+	myAddr := n.core.DEBUG_getGlobalTCPAddr()
 	anAddr.Port = myAddr.Port
 	destAddr, err := net.ResolveUDPAddr("udp6", multicastAddr)
 	if err != nil {

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -118,7 +118,7 @@ func generateConfig() *nodeConfig {
 	cfg.Multicast = true
 	cfg.LinkLocal = ""
 	cfg.IfName = "auto"
-	cfg.IfMTU = 1280 //65535
+	cfg.IfMTU = 1280
 	if runtime.GOOS == "windows" {
 		cfg.IfTAPMode = true
 	} else {


### PR DESCRIPTION
There's a few different changes in this PR. The highlights are:

1. There's non-backwards-compatible cleanup of a couple of wire packet formats. This removes unnecessary crypto keys from the inner layer of the packets (the keys were already visible in the crypto header, they don't need to be on the inside too) for DHT req/res packets and peer announcement and hop req/res packets. Together, these things reduce the idle bandwidth consumption of the network by some constant but non-negligible factor. **Nodes that fail to update will be unable to communicate with nodes that have.**
2. Peer announcements are throttled. Instead of always being sent 1/second, it checks to decide if it  should send once every second. Every 4th packet is sent, or a packet is sent every time we recognize that someone's information is out of date (our coords changed, or seeing that we need to acknowledge that a peer's coords changed).
3. Nodes will ignore tree updates if the only difference is the root timestamp and the node has updated the root timestamp within the past 10 seconds. This throttles the maximum rate at which root timestamps can be updated, which could have been used by malicious roots to waste resources or try to DoS the network (by updating timestamps faster than nodes can propagate coordinate updates and signatures).
4. TCP links have internally switched from using `net.Buffers` to using `bufio.Writer`. This may reduce the cost of forwarding many small packets over TCP at the switch layer, by writing many small packets to the stream with 1 syscall (instead of one call per packet). The extra overhead from copying to the bufio buffer may slightly reduce throughput for sending large packets. Additional tuning may be needed.
5. There are issues currently on master where using a large MTU and sending over a UDP link can cause encapsulated TCP streams to consistently drop large packets and throttle down to 0. When this occurs, the stream seems to become permanently stuck in a broken state, and never recover. If the stream is closed and a new stream is open, the new one seems to work fine. I haven't figured out where this stateful behavior is coming from, but as a temporary workaround, PMTU has been capped (at the session level) at 2048. As far as I can tell, this is low enough to avoid freezing TCP streams. The default MTU has been reduced back to 1280, and setting it higher than 2048 is currently useless.