### PR TITLE
Mostly working PMTU discovery when going over UDP links

### DIFF
--- a/src/yggdrasil/crypto.go
+++ b/src/yggdrasil/crypto.go
@@ -91,6 +91,7 @@ const boxPubKeyLen = 32
 const boxPrivKeyLen = 32
 const boxSharedKeyLen = 32
 const boxNonceLen = 24
+const boxOverhead = box.Overhead
 
 type boxPubKey [boxPubKeyLen]byte
 type boxPrivKey [boxPrivKeyLen]byte

--- a/src/yggdrasil/udp.go
+++ b/src/yggdrasil/udp.go
@@ -182,6 +182,13 @@ func (iface *udpInterface) handleKeys(msg []byte, addr connAddr) {
 			//defer util_putBytes(bs)
 			chunks, chunk, count, payload := udp_decode(bs)
 			if count != conn.countIn {
+				if len(inBuf) > 0 {
+					// Something went wrong
+					// Forward whatever we have
+					// Maybe the destination can do something about it
+					msg := append(util_getBytes(), inBuf...)
+					conn.peer.handlePacket(msg, conn.linkIn)
+				}
 				inChunks = 0
 				inBuf = inBuf[:0]
 				conn.countIn = count
@@ -194,6 +201,7 @@ func (iface *udpInterface) handleKeys(msg []byte, addr connAddr) {
 				}
 				msg := append(util_getBytes(), inBuf...)
 				conn.peer.handlePacket(msg, conn.linkIn)
+				inBuf = inBuf[:0]
 			}
 		}
 		conn.peer.out = func(msg []byte) {


### PR DESCRIPTION
Changes a few things to try to make PMTU play nicer with UDP links that go over intermediate routers.

1. Removed temporary workaround that set PMTU to at most 2048, now it will default to the smaller tun/tap MTU out of the two end points of a session.
2. When some chunks of a manually fragmented UDP packet fail to make it across (in order), send the parts that were successful instead of dropping them when a new packet comes in, so the end point can receive *something* and try to figure out how to deal with it.
3. When receiving an invalid packet (one that fails at the crypto layer), guess that the packet was missing chunks and reduce the session MTU accordingly, to a minimum of 1280. This *should* eventually find the real MTU of the smallest link that the traffic passes through.
4. Reset the `myMTU` side of a session MTU to the tun/tap value 1 minute after it was last changed, to give OS-level PMTU probes a chance to realize something has changed, the path has changed and the PMTU can be increased.

It should be noted that 3 is very aggressive. There are cases where reducing the PMTU to the MTU of the lowest link seems to cause lower total bandwidth than using larger PMTU and chunking packets. This leads to weird behaviors, such as a wired ethernet connection losing bandwidth suddenly after several minutes, when the PMTU is finally clamped due to random packet loss. An improved version could take packet loss rate into account (based on something like the session nonce progression to track the number of expected and successful packets), but I haven't found a nice way to do that yet.

TCP is currently kept as the default peering mechanism, and the default MTU is still set to 1280, to give nodes a chance to upgrade (support for part 2 needs to be wide spread before 3/4 can work safely with larger packets).