### PR TITLE
Add support for running OpenBSD

### DIFF
--- a/misc/tests/tunbench-client.go
+++ b/misc/tests/tunbench-client.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/songgao/water"
+	"github.com/neilalexander/water"
 )
 
 const mtu = 65535

--- a/misc/tests/tunbench-server.go
+++ b/misc/tests/tunbench-server.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os/exec"
 
-	"github.com/songgao/water"
+	"github.com/neilalexander/water"
 )
 
 const mtu = 65535

--- a/misc/tests/tunbench.go
+++ b/misc/tests/tunbench.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os/exec"
 
-	"github.com/songgao/water"
+	"github.com/neilalexander/water"
 )
 
 const mtu = 65535

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -6,6 +6,7 @@ import "bytes"
 import "fmt"
 import "sort"
 import "strings"
+import "strconv"
 
 // TODO? Make all of this JSON
 // TODO: Add authentication
@@ -55,11 +56,45 @@ func (a *admin) init(c *Core, listenaddr string) {
 	a.addHandler("getSessions", nil, func(out *[]byte, _ ...string) {
 		*out = []byte(a.printInfos(a.getData_getSessions()))
 	})
-	a.addHandler("addPeer", nil, func(out *[]byte, saddr ...string) {
+	a.addHandler("addPeer", []string{"<peer>"}, func(out *[]byte, saddr ...string) {
 		if a.addPeer(saddr[0]) == nil {
 			*out = []byte("Adding peer: " + saddr[0] + "\n")
 		} else {
 			*out = []byte("Failed to add peer: " + saddr[0] + "\n")
+		}
+	})
+	a.addHandler("setTunTap", []string{"<ifname|auto|none>", "[<tun|tap>]", "[<mtu>]"}, func(out *[]byte, ifparams ...string) {
+		// Check parameters
+		if (ifparams[0] != "none" && len(ifparams) != 3) ||
+			(ifparams[0] == "none" && len(ifparams) != 1) {
+			*out = []byte("Invalid number of parameters given\n")
+			return
+		}
+		// Set sane defaults
+		iftapmode := false
+		ifmtu := 1280
+		var err error
+		if len(ifparams) > 1 {
+			// Is it a TAP adapter?
+			if ifparams[1] == "tap" {
+				iftapmode = true
+			}
+			// Make sure the MTU is sane
+			ifmtu, err = strconv.Atoi(ifparams[2])
+			if err != nil || ifmtu < 1280 || ifmtu > 65535 {
+				ifmtu = 1280
+			}
+		}
+		// Start the TUN adapter
+		if err := a.startTunWithMTU(ifparams[0], iftapmode, ifmtu); err != nil {
+			*out = []byte(fmt.Sprintf("Failed to set TUN: %v\n", err))
+		} else {
+			info := admin_nodeInfo{
+				{"Interface name", ifparams[0]},
+				{"TAP mode", strconv.FormatBool(iftapmode)},
+				{"MTU", strconv.Itoa(ifmtu)},
+			}
+			*out = []byte(a.printInfos([]admin_nodeInfo{info}))
 		}
 	})
 	go a.listen()
@@ -180,6 +215,23 @@ func (a *admin) addPeer(p string) error {
 		}
 		a.core.tcp.call(p)
 	}
+	return nil
+}
+
+func (a *admin) startTunWithMTU(ifname string, iftapmode bool, ifmtu int) error {
+	// Close the TUN first if open
+	_ = a.core.tun.close()
+	// Then reconfigure and start it
+	addr := a.core.router.addr
+	straddr := fmt.Sprintf("%s/%v", net.IP(addr[:]).String(), 8*len(address_prefix))
+	if ifname != "none" {
+		err := a.core.tun.setup(ifname, iftapmode, straddr, ifmtu)
+		if err != nil {
+			return err
+		}
+		go a.core.tun.read()
+	}
+	go a.core.tun.write()
 	return nil
 }
 

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -64,21 +64,19 @@ func (a *admin) init(c *Core, listenaddr string) {
 		}
 	})
 	a.addHandler("setTunTap", []string{"<ifname|auto|none>", "[<tun|tap>]", "[<mtu>]"}, func(out *[]byte, ifparams ...string) {
-		// Check parameters
-		if (ifparams[0] != "none" && len(ifparams) != 3) ||
-			(ifparams[0] == "none" && len(ifparams) != 1) {
-			*out = []byte("Invalid number of parameters given\n")
-			return
-		}
 		// Set sane defaults
 		iftapmode := false
 		ifmtu := 1280
 		var err error
+		// Check we have enough params for TAP mode
 		if len(ifparams) > 1 {
 			// Is it a TAP adapter?
 			if ifparams[1] == "tap" {
 				iftapmode = true
 			}
+		}
+		// Check we have enough params for MTU
+		if len(ifparams) > 2 {
 			// Make sure the MTU is sane
 			ifmtu, err = strconv.Atoi(ifparams[2])
 			if err != nil || ifmtu < 1280 || ifmtu > 65535 {

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -159,6 +159,20 @@ func (c *Core) DEBUG_getDHTSize() int {
 	return total
 }
 
+// TUN defaults
+
+func (c *Core) DEBUG_GetTUNDefaultIfName() string {
+	return getDefaults().defaultIfName
+}
+
+func (c *Core) DEBUG_GetTUNDefaultIfMTU() int {
+	return getDefaults().defaultIfMTU
+}
+
+func (c *Core) DEBUG_GetTUNDefaultIfTAPMode() bool {
+	return getDefaults().defaultIfTAPMode
+}
+
 // udpInterface
 //  FIXME udpInterface isn't exported
 //  So debug functions need to work differently...

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -5,6 +5,8 @@ package yggdrasil
 import "os"
 import ethernet "github.com/songgao/packets/ethernet"
 
+const DEFAULT_MTU = 65535
+
 const IPv6_HEADER_LENGTH = 40
 const ETHER_HEADER_LENGTH = 14
 
@@ -28,12 +30,15 @@ type tunDevice struct {
 }
 
 type tunDefaultParameters struct {
-	maxMTU	int
+	maximumIfMTU	   int
+	defaultIfMTU     int
+	defaultIfName	   string
+	defaultIfTAPMode bool
 }
 
-func getMTUFromMax(mtu int) int {
-	if mtu > defaultTUNParameters().maxMTU {
-		return defaultTUNParameters().maxMTU
+func getSupportedMTU(mtu int) int {
+	if mtu > getDefaults().maximumIfMTU {
+		return getDefaults().maximumIfMTU
 	}
 	return mtu
 }

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -2,6 +2,7 @@ package yggdrasil
 
 // This manages the tun driver to send/recv packets to/from applications
 
+import "os"
 import ethernet "github.com/songgao/packets/ethernet"
 
 const IPv6_HEADER_LENGTH = 40
@@ -14,6 +15,7 @@ type tunInterface interface {
 	Read(to []byte) (int, error)
 	Write(from []byte) (int, error)
 	Close() error
+	FD() *os.File
 }
 
 type tunDevice struct {

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -5,8 +5,6 @@ package yggdrasil
 import "os"
 import ethernet "github.com/songgao/packets/ethernet"
 
-const DEFAULT_MTU = 65535
-
 const IPv6_HEADER_LENGTH = 40
 const ETHER_HEADER_LENGTH = 14
 

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -66,7 +66,8 @@ func (tun *tunDevice) read() error {
 	for {
 		n, err := tun.iface.Read(buf)
 		if err != nil {
-			panic(err)
+			// panic(err)
+			return err
 		}
 		o := 0
 		if tun.iface.IsTAP() {

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -27,6 +27,17 @@ type tunDevice struct {
 	iface  tunInterface
 }
 
+type tunDefaultParameters struct {
+	maxMTU	int
+}
+
+func getMTUFromMax(mtu int) int {
+	if mtu > defaultTUNParameters().maxMTU {
+		return defaultTUNParameters().maxMTU
+	}
+	return mtu
+}
+
 func (tun *tunDevice) init(core *Core) {
 	tun.core = core
 	tun.icmpv6.init(tun)

--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -2,16 +2,18 @@
 
 package yggdrasil
 
-import "fmt"
 import "os/exec"
 import "strings"
+import "unsafe"
+import "syscall"
+import "golang.org/x/sys/unix"
 
 import water "github.com/neilalexander/water"
 
 // This is to catch BSD platforms
 
-const TUNSIFINFO = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
-const TUNGIFINFO = (0x40000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
+const TUNSIFINFO = (0x80000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
+const TUNGIFINFO = (0x40000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
 const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
 
 type in6_addrlifetime struct {
@@ -40,10 +42,10 @@ type in6_aliasreq struct {
 }
 
 type tuninfo struct {
-	tun_baudrate int
-	tun_mtu      int16
-	tun_type     uint8
-	tun_dummy    uint8
+	tun_mtu     uint16
+	tun_type    uint32
+	tun_flags   uint32
+	tun_dummy   uint16
 }
 
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
@@ -67,23 +69,46 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 }
 
 func (tun *tunDevice) setupAddress(addr string) error {
+	fd := tun.iface.FD().Fd()
+	var err error
+	var ti tuninfo
+
+	// Get the existing interface flags
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNGIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
+		err = errno
+		tun.core.log.Printf("Error in TUNGIFINFO: %v", errno)
+		return err
+	}
+	tun.core.log.Printf("TUNGIFINFO: %+v", ti)
+
+	// Set the new MTU
+	ti.tun_mtu = uint16(tun.mtu)
+
+	// Set the new interface flags
+	ti.tun_flags |= syscall.IFF_UP
+	switch {
+	case tun.iface.IsTAP():
+		ti.tun_flags |= syscall.IFF_MULTICAST
+		ti.tun_flags |= syscall.IFF_BROADCAST
+	case tun.iface.IsTUN():
+		ti.tun_flags |= syscall.IFF_POINTOPOINT
+	}
+
+	// Set the new interface flags
+	tun.core.log.Printf("TUNSIFINFO: %+v", ti)
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNSIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
+		err = errno
+		tun.core.log.Printf("Error in TUNSIFINFO: %v", errno)
+		return err
+	}
+
 	// Set address
 	cmd := exec.Command("ifconfig", tun.iface.Name(), "inet6", addr)
 	tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		tun.core.log.Printf("ipconfig failed: %v.", err)
+		tun.core.log.Printf("ifconfig failed: %v.", err)
 		tun.core.log.Println(string(output))
-		return err
-	}
-	// Set MTU and bring device up
-	cmd = exec.Command("ifconfig", tun.iface.Name(), "mtu", fmt.Sprintf("%d", tun.mtu), "up")
-	tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		tun.core.log.Printf("ipconfig failed: %v.", err)
-		tun.core.log.Println(string(output))
-		return err
 	}
 
 	return nil

--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -1,17 +1,60 @@
-// +build openbsd freebsd solaris
+// +build openbsd freebsd solaris netbsd dragonfly
 
 package yggdrasil
+
+import "fmt"
+import "os/exec"
+import "strings"
 
 import water "github.com/neilalexander/water"
 
 // This is to catch BSD platforms
 
+const TUNSIFINFO = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
+const TUNGIFINFO = (0x40000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
+const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
+
+type in6_addrlifetime struct {
+	ia6t_expire    float64
+	ia6t_preferred float64
+	ia6t_vltime    uint32
+	ia6t_pltime    uint32
+}
+
+type sockaddr_in6 struct {
+	sin6_len      uint8
+	sin6_family   uint8
+	sin6_port     uint8
+	sin6_flowinfo uint32
+	sin6_addr     [8]uint16
+	sin6_scope_id uint32
+}
+
+type in6_aliasreq struct {
+	ifra_name       [16]byte
+	ifra_addr       sockaddr_in6
+	ifra_dstaddr    sockaddr_in6
+	ifra_prefixmask sockaddr_in6
+	ifra_flags      uint32
+	ifra_lifetime   in6_addrlifetime
+}
+
+type tuninfo struct {
+	tun_baudrate int
+	tun_mtu      int16
+	tun_type     uint8
+	tun_dummy    uint8
+}
+
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	var config water.Config
-	if iftapmode {
+	switch {
+	case iftapmode || ifname[:8] == "/dev/tap":
 		config = water.Config{DeviceType: water.TAP}
-	} else {
+	case !iftapmode || ifname[:8] == "/dev/tun":
 		config = water.Config{DeviceType: water.TUN}
+	default:
+		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
 	}
 	config.Name = ifname
 	iface, err := water.New(config)
@@ -24,6 +67,24 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 }
 
 func (tun *tunDevice) setupAddress(addr string) error {
-	tun.core.log.Println("Platform not supported, you must set the address of", tun.iface.Name(), "to", addr)
+	// Set address
+	cmd := exec.Command("ifconfig", tun.iface.Name(), "inet6", addr)
+	tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		tun.core.log.Printf("ipconfig failed: %v.", err)
+		tun.core.log.Println(string(output))
+		return err
+	}
+	// Set MTU and bring device up
+	cmd = exec.Command("ifconfig", tun.iface.Name(), "mtu", fmt.Sprintf("%d", tun.mtu), "up")
+	tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		tun.core.log.Printf("ipconfig failed: %v.", err)
+		tun.core.log.Println(string(output))
+		return err
+	}
+
 	return nil
 }

--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -1,16 +1,10 @@
-// +build !linux
-// +build !darwin
-// +build !windows
-// +build !openbsd
-// +build !freebsd
-// +build !solaris
+// +build openbsd freebsd solaris
 
 package yggdrasil
 
 import water "github.com/neilalexander/water"
 
-// This is to catch unsupported platforms
-// If your platform supports tun devices, you could try configuring it manually
+// This is to catch BSD platforms
 
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	var config water.Config
@@ -19,6 +13,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 	} else {
 		config = water.Config{DeviceType: water.TUN}
 	}
+	config.Name = ifname
 	iface, err := water.New(config)
 	if err != nil {
 		panic(err)

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -13,7 +13,7 @@ import water "github.com/neilalexander/water"
 func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
 		maximumIfMTU:     65535,
-		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfMTU:     65535,
 		defaultIfName:    "auto",
 		defaultIfTAPMode: false,
 	}

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -8,7 +8,7 @@ import "strconv"
 import "encoding/binary"
 import "golang.org/x/sys/unix"
 
-import water "github.com/songgao/water"
+import water "github.com/neilalexander/water"
 
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	if iftapmode {

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -10,9 +10,12 @@ import "golang.org/x/sys/unix"
 
 import water "github.com/neilalexander/water"
 
-func defaultTUNParameters() tunDefaultParameters {
+func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
-		maxMTU: 65535,
+		maximumIfMTU:     65535,
+		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfName:    "auto",
+		defaultIfTAPMode: false,
 	}
 }
 
@@ -26,7 +29,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getMTUFromMax(mtu)
+	tun.mtu = getSupportedMTU(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -10,6 +10,12 @@ import "golang.org/x/sys/unix"
 
 import water "github.com/neilalexander/water"
 
+func defaultTUNParameters() tunDefaultParameters {
+	return tunDefaultParameters{
+		maxMTU: 65535,
+	}
+}
+
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	if iftapmode {
 		tun.core.log.Printf("TAP mode is not supported on this platform, defaulting to TUN")
@@ -20,7 +26,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = mtu
+	tun.mtu = getMTUFromMax(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -12,7 +12,7 @@ import water "github.com/neilalexander/water"
 func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
 		maximumIfMTU:     65535,
-		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfMTU:     65535,
 		defaultIfName:    "auto",
 		defaultIfTAPMode: false,
 	}

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -9,9 +9,12 @@ import "strings"
 
 import water "github.com/neilalexander/water"
 
-func defaultTUNParameters() tunDefaultParameters {
+func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
-		maxMTU: 65535,
+		maximumIfMTU:     65535,
+		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfName:    "auto",
+		defaultIfTAPMode: false,
 	}
 }
 
@@ -30,7 +33,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getMTUFromMax(mtu)
+	tun.mtu = getSupportedMTU(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -7,7 +7,7 @@ import "fmt"
 import "os/exec"
 import "strings"
 
-import water "github.com/songgao/water"
+import water "github.com/neilalexander/water"
 
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	var config water.Config

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -9,6 +9,12 @@ import "strings"
 
 import water "github.com/neilalexander/water"
 
+func defaultTUNParameters() tunDefaultParameters {
+	return tunDefaultParameters{
+		maxMTU: 65535,
+	}
+}
+
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	var config water.Config
 	if iftapmode {
@@ -24,7 +30,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = mtu //1280 // Lets default to the smallest thing allowed for now
+	tun.mtu = getMTUFromMax(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_openbsd.go
+++ b/src/yggdrasil/tun_openbsd.go
@@ -15,6 +15,12 @@ import water "github.com/neilalexander/water"
 // to disable the PI header when in TUN mode, so we need to modify the read/
 // writes to handle those first four bytes
 
+func defaultTUNParameters() tunDefaultParameters {
+	return tunDefaultParameters{
+		maxMTU: 16384,
+	}
+}
+
 // Warning! When porting this to other BSDs, the tuninfo struct can appear with
 // the fields in a different order, and the consts below might also have
 // different values
@@ -80,7 +86,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = mtu //1280 // Lets default to the smallest thing allowed for now
+	tun.mtu = getMTUFromMax(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_openbsd.go
+++ b/src/yggdrasil/tun_openbsd.go
@@ -15,9 +15,12 @@ import water "github.com/neilalexander/water"
 // to disable the PI header when in TUN mode, so we need to modify the read/
 // writes to handle those first four bytes
 
-func defaultTUNParameters() tunDefaultParameters {
+func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
-		maxMTU: 16384,
+		maximumIfMTU:     16384,
+		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfName:    "/dev/tap0",
+		defaultIfTAPMode: true,
 	}
 }
 
@@ -86,7 +89,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getMTUFromMax(mtu)
+	tun.mtu = getSupportedMTU(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_openbsd.go
+++ b/src/yggdrasil/tun_openbsd.go
@@ -1,4 +1,4 @@
-// +build openbsd freebsd solaris netbsd dragonfly
+// +build openbsd
 
 package yggdrasil
 
@@ -10,11 +10,24 @@ import "golang.org/x/sys/unix"
 
 import water "github.com/neilalexander/water"
 
-// This is to catch BSD platforms
+// This is to catch OpenBSD
+
+// Warning! When porting this to other BSDs, the tuninfo struct can appear with
+// the fields in a different order, and the consts below might also have
+// different values
+
+type tuninfo struct {
+	tun_mtu     uint16
+	tun_type    uint32
+	tun_flags   uint32
+	tun_dummy   uint16
+}
 
 const TUNSIFINFO = (0x80000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
 const TUNGIFINFO = (0x40000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
 const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
+
+// Below this point seems to be fairly standard at least...
 
 type in6_addrlifetime struct {
 	ia6t_expire    float64
@@ -39,13 +52,6 @@ type in6_aliasreq struct {
 	ifra_prefixmask sockaddr_in6
 	ifra_flags      uint32
 	ifra_lifetime   in6_addrlifetime
-}
-
-type tuninfo struct {
-	tun_mtu     uint16
-	tun_type    uint32
-	tun_flags   uint32
-	tun_dummy   uint16
 }
 
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {

--- a/src/yggdrasil/tun_openbsd.go
+++ b/src/yggdrasil/tun_openbsd.go
@@ -18,7 +18,7 @@ import water "github.com/neilalexander/water"
 func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
 		maximumIfMTU:     16384,
-		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfMTU:     16384,
 		defaultIfName:    "/dev/tap0",
 		defaultIfTAPMode: true,
 	}

--- a/src/yggdrasil/tun_openbsd.go
+++ b/src/yggdrasil/tun_openbsd.go
@@ -3,7 +3,6 @@
 package yggdrasil
 
 import "os/exec"
-import "strings"
 import "unsafe"
 import "syscall"
 import "golang.org/x/sys/unix"
@@ -90,13 +89,17 @@ func (tun *tunDevice) setupAddress(addr string) error {
 	var err error
 	var ti tuninfo
 
+	tun.core.log.Printf("Interface name: %s", tun.iface.Name())
+	tun.core.log.Printf("Interface IPv6: %s", addr)
+	tun.core.log.Printf("Interface MTU: %d", tun.mtu)
+
 	// Get the existing interface flags
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNGIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
 		err = errno
 		tun.core.log.Printf("Error in TUNGIFINFO: %v", errno)
 		return err
 	}
-	tun.core.log.Printf("TUNGIFINFO: %+v", ti)
+	//tun.core.log.Printf("TUNGIFINFO: %+v", ti)
 
 	// Set the new MTU
 	ti.tun_mtu = uint16(tun.mtu)
@@ -112,7 +115,7 @@ func (tun *tunDevice) setupAddress(addr string) error {
 	}
 
 	// Set the new interface flags
-	tun.core.log.Printf("TUNSIFINFO: %+v", ti)
+	//tun.core.log.Printf("TUNSIFINFO: %+v", ti)
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNSIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
 		err = errno
 		tun.core.log.Printf("Error in TUNSIFINFO: %v", errno)
@@ -121,7 +124,7 @@ func (tun *tunDevice) setupAddress(addr string) error {
 
 	// Set address
 	cmd := exec.Command("ifconfig", tun.iface.Name(), "inet6", addr)
-	tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
+	//tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		tun.core.log.Printf("ifconfig failed: %v.", err)

--- a/src/yggdrasil/tun_other.go
+++ b/src/yggdrasil/tun_other.go
@@ -7,9 +7,12 @@ import water "github.com/neilalexander/water"
 // This is to catch unsupported platforms
 // If your platform supports tun devices, you could try configuring it manually
 
-func defaultTUNParameters() tunDefaultParameters {
+func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
-		maxMTU: 65535,
+		maximumIfMTU:     65535,
+		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfName:    "none",
+		defaultIfTAPMode: false,
 	}
 }
 
@@ -25,7 +28,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getMTUFromMax(mtu)
+	tun.mtu = getSupportedMTU(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_other.go
+++ b/src/yggdrasil/tun_other.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!windows,!openbsd,!freebsd,!solaris,!netbsd,!dragonfly
+// +build !linux,!darwin,!windows,!openbsd
 
 package yggdrasil
 

--- a/src/yggdrasil/tun_other.go
+++ b/src/yggdrasil/tun_other.go
@@ -7,6 +7,12 @@ import water "github.com/neilalexander/water"
 // This is to catch unsupported platforms
 // If your platform supports tun devices, you could try configuring it manually
 
+func defaultTUNParameters() tunDefaultParameters {
+	return tunDefaultParameters{
+		maxMTU: 65535,
+	}
+}
+
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	var config water.Config
 	if iftapmode {
@@ -19,7 +25,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = mtu //1280 // Lets default to the smallest thing allowed for now
+	tun.mtu = getMTUFromMax(mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_other.go
+++ b/src/yggdrasil/tun_other.go
@@ -1,9 +1,4 @@
-// +build !linux
-// +build !darwin
-// +build !windows
-// +build !openbsd
-// +build !freebsd
-// +build !solaris
+// +build !linux,!darwin,!windows,!openbsd,!freebsd,!solaris,!netbsd,!dragonfly
 
 package yggdrasil
 

--- a/src/yggdrasil/tun_other.go
+++ b/src/yggdrasil/tun_other.go
@@ -10,7 +10,7 @@ import water "github.com/neilalexander/water"
 func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
 		maximumIfMTU:     65535,
-		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfMTU:     65535,
 		defaultIfName:    "none",
 		defaultIfTAPMode: false,
 	}

--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -10,7 +10,7 @@ import "fmt"
 func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
 		maximumIfMTU:     65535,
-		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfMTU:     65535,
 		defaultIfName:    "auto",
 		defaultIfTAPMode: true,
 	}

--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -1,6 +1,6 @@
 package yggdrasil
 
-import water "github.com/songgao/water"
+import water "github.com/neilalexander/water"
 import "os/exec"
 import "strings"
 import "fmt"

--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -7,6 +7,12 @@ import "fmt"
 
 // This is to catch Windows platforms
 
+func defaultTUNParameters() tunDefaultParameters {
+	return tunDefaultParameters{
+		maxMTU: 65535,
+	}
+}
+
 func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	if !iftapmode {
 		tun.core.log.Printf("TUN mode is not supported on this platform, defaulting to TAP")
@@ -41,7 +47,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = mtu
+	tun.mtu = getMTUFromMax(mtu)
 	err = tun.setupMTU(tun.mtu)
 	if err != nil {
 		panic(err)

--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -7,9 +7,12 @@ import "fmt"
 
 // This is to catch Windows platforms
 
-func defaultTUNParameters() tunDefaultParameters {
+func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{
-		maxMTU: 65535,
+		maximumIfMTU:     65535,
+		defaultIfMTU:     DEFAULT_MTU,
+		defaultIfName:    "auto",
+		defaultIfTAPMode: true,
 	}
 }
 
@@ -47,7 +50,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getMTUFromMax(mtu)
+	tun.mtu = getSupportedMTU(mtu)
 	err = tun.setupMTU(tun.mtu)
 	if err != nil {
 		panic(err)

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -117,13 +117,9 @@ func generateConfig() *nodeConfig {
 	cfg.Peers = []string{}
 	cfg.Multicast = true
 	cfg.LinkLocal = ""
-	cfg.IfName = "auto"
-	cfg.IfMTU = 1280
-	if runtime.GOOS == "windows" {
-		cfg.IfTAPMode = true
-	} else {
-		cfg.IfTAPMode = false
-	}
+	cfg.IfName = core.DEBUG_GetTUNDefaultIfName()
+	cfg.IfMTU = core.DEBUG_GetTUNDefaultIfMTU()
+	cfg.IfTAPMode = core.DEBUG_GetTUNDefaultIfTAPMode()
 	return &cfg
 }
 


### PR DESCRIPTION
Adds support for OpenBSD.

This currently only supports TAP mode, as we don't currently have code to support the Protocol Information header (4 bytes) as this cannot be disabled in TUN mode on OpenBSD.

This code can also be used as a template for supporting other BSDs, although some of the structs and constants may have different orders or values, i.e. `struct tuninfo` is in a different order on FreeBSD.