### PR TITLE
Add admin functions for adding peers and modifying TUN/TAP

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -6,6 +6,7 @@ import "bytes"
 import "fmt"
 import "sort"
 import "strings"
+import "strconv"
 
 // TODO? Make all of this JSON
 // TODO: Add authentication
@@ -55,11 +56,45 @@ func (a *admin) init(c *Core, listenaddr string) {
 	a.addHandler("getSessions", nil, func(out *[]byte, _ ...string) {
 		*out = []byte(a.printInfos(a.getData_getSessions()))
 	})
-	a.addHandler("addPeer", nil, func(out *[]byte, saddr ...string) {
+	a.addHandler("addPeer", []string{"<peer>"}, func(out *[]byte, saddr ...string) {
 		if a.addPeer(saddr[0]) == nil {
 			*out = []byte("Adding peer: " + saddr[0] + "\n")
 		} else {
 			*out = []byte("Failed to add peer: " + saddr[0] + "\n")
+		}
+	})
+	a.addHandler("setTunTap", []string{"<ifname|auto|none>", "[<tun|tap>]", "[<mtu>]"}, func(out *[]byte, ifparams ...string) {
+		// Check parameters
+		if (ifparams[0] != "none" && len(ifparams) != 3) ||
+			(ifparams[0] == "none" && len(ifparams) != 1) {
+			*out = []byte("Invalid number of parameters given\n")
+			return
+		}
+		// Set sane defaults
+		iftapmode := false
+		ifmtu := 1280
+		var err error
+		if len(ifparams) > 1 {
+			// Is it a TAP adapter?
+			if ifparams[1] == "tap" {
+				iftapmode = true
+			}
+			// Make sure the MTU is sane
+			ifmtu, err = strconv.Atoi(ifparams[2])
+			if err != nil || ifmtu < 1280 || ifmtu > 65535 {
+				ifmtu = 1280
+			}
+		}
+		// Start the TUN adapter
+		if err := a.startTunWithMTU(ifparams[0], iftapmode, ifmtu); err != nil {
+			*out = []byte(fmt.Sprintf("Failed to set TUN: %v\n", err))
+		} else {
+			info := admin_nodeInfo{
+				{"Interface name", ifparams[0]},
+				{"TAP mode", strconv.FormatBool(iftapmode)},
+				{"MTU", strconv.Itoa(ifmtu)},
+			}
+			*out = []byte(a.printInfos([]admin_nodeInfo{info}))
 		}
 	})
 	go a.listen()
@@ -180,6 +215,23 @@ func (a *admin) addPeer(p string) error {
 		}
 		a.core.tcp.call(p)
 	}
+	return nil
+}
+
+func (a *admin) startTunWithMTU(ifname string, iftapmode bool, ifmtu int) error {
+	// Close the TUN first if open
+	_ = a.core.tun.close()
+	// Then reconfigure and start it
+	addr := a.core.router.addr
+	straddr := fmt.Sprintf("%s/%v", net.IP(addr[:]).String(), 8*len(address_prefix))
+	if ifname != "none" {
+		err := a.core.tun.setup(ifname, iftapmode, straddr, ifmtu)
+		if err != nil {
+			return err
+		}
+		go a.core.tun.read()
+	}
+	go a.core.tun.write()
 	return nil
 }
 

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -64,21 +64,19 @@ func (a *admin) init(c *Core, listenaddr string) {
 		}
 	})
 	a.addHandler("setTunTap", []string{"<ifname|auto|none>", "[<tun|tap>]", "[<mtu>]"}, func(out *[]byte, ifparams ...string) {
-		// Check parameters
-		if (ifparams[0] != "none" && len(ifparams) != 3) ||
-			(ifparams[0] == "none" && len(ifparams) != 1) {
-			*out = []byte("Invalid number of parameters given\n")
-			return
-		}
 		// Set sane defaults
 		iftapmode := false
 		ifmtu := 1280
 		var err error
+		// Check we have enough params for TAP mode
 		if len(ifparams) > 1 {
 			// Is it a TAP adapter?
 			if ifparams[1] == "tap" {
 				iftapmode = true
 			}
+		}
+		// Check we have enough params for MTU
+		if len(ifparams) > 2 {
 			// Make sure the MTU is sane
 			ifmtu, err = strconv.Atoi(ifparams[2])
 			if err != nil || ifmtu < 1280 || ifmtu > 65535 {

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -66,7 +66,8 @@ func (tun *tunDevice) read() error {
 	for {
 		n, err := tun.iface.Read(buf)
 		if err != nil {
-			panic(err)
+			// panic(err)
+			return err
 		}
 		o := 0
 		if tun.iface.IsTAP() {


### PR DESCRIPTION
This adds new admin functions for adding peers and modifying the TUN/TAP interface without restarting Yggdrasil. Note that changes made in realtime are **not** written to configuration!

New commands are:

- `addPeer a.a.a.a:b` to add a peer using the default protocol
- `addPeer tcp:a.a.a.a:b` to add a TCP peer
- `addPeer udp:a.a.a.a:b` to add a UDP peer 
- `setTunTap none` to remove the TUN/TAP interface
- `setTunTap auto tun` to configure an unspecified TUN interface with default MTU
- `setTunTap auto tap 1500` to configure an unspecified TAP interface with MTU 1500
- `setTunTap /dev/tap0 tap 1280` to configure a specified TAP interface with MTU 1280