### PR TITLE
Add a script to generate .deb files for Debian amd64/i386

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.9
+
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+
+    steps:
+      - checkout
+      - run:
+          name: Create artifact upload directory
+          command: mkdir /tmp/upload
+
+      - run:
+          name: Build for Linux (including Debian packages)
+          command: |
+              PKGARCH=amd64 sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-linux-amd64;
+              PKGARCH=i386 sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-linux-i386;
+              PKGARCH=mipsel sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-linux-mipsel;
+              PKGARCH=mips sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-linux-mips;
+              mv *.deb /tmp/upload/
+
+      - run:
+          name: Build for macOS
+          command: |
+              GOOS=darwin GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/yggdrasil-darwin-amd64;
+              GOOS=darwin GOARCH=386 ./build && mv yggdrasil /tmp/upload/yggdrasil-darwin-i386;
+
+      - run:
+          name: Build for OpenBSD
+          command: |
+              GOOS=openbsd GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/yggdrasil-linux-amd64;
+              GOOS=openbsd GOARCH=386 ./build && mv yggdrasil /tmp/upload/yggdrasil-linux-i386;
+
+      - run:
+          name: Build for Windows
+          command: |
+              GOOS=windows GOARCH=amd64 ./build && mv yggdrasil.exe /tmp/upload/yggdrasil-windows-amd64.exe;
+              GOOS=windows GOARCH=386 ./build && mv yggdrasil.exe /tmp/upload/yggdrasil-windows-i386.exe;
+
+      - run:
+          name: Build for EdgeRouter
+          command: |
+              git clone https://github.com/neilalexander/vyatta-yggdrasil /tmp/vyatta-yggdrasil;
+              cd /tmp/vyatta-yggdrasil;
+              BUILDDIR_YGG=$CIRCLE_WORKING_DIRECTORY ./build-edgerouter-x $CIRCLE_BRANCH;
+              BUILDDIR_YGG=$CIRCLE_WORKING_DIRECTORY ./build-edgerouter-lite $CIRCLE_BRANCH;
+              mv *.deb /tmp/upload;
+
+      - store_artifacts:
+          path: /tmp/upload
+          destination: /

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -57,7 +57,8 @@ systemctl disable yggdrasil
 systemctl stop yggdrasil
 EOF
 
-GOOS=linux GOARCH=$PKGARCH ./build
+if [ $PKGARCH = "amd64" ]; then GOARCH=amd64 GOOS=linux ./build; fi
+if [ $PKGARCH = "i386" ]; then GOARCH=386 GOOS=linux ./build; fi
 
 cp yggdrasil /tmp/$PKGNAME/usr/bin/
 cp contrib/systemd/yggdrasil.service /tmp/$PKGNAME/etc/systemd/system/
@@ -76,4 +77,3 @@ ar -r $PKGFILE \
   /tmp/$PKGNAME/data.tar.gz
 
 rm -rf /tmp/$PKGNAME
-

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -10,10 +10,17 @@ then
   exit -1
 fi
 
-PKGNAME=debian-yggdrasil
+PKGNAME=yggdrasil
 PKGARCH=${PKGARCH-amd64}
 PKGVERSION=0.$(git rev-list HEAD --count 2>/dev/null | xargs printf "%04d")
 PKGFILE=$PKGNAME-$PKGVERSION-$PKGARCH.deb
+
+if [ $PKGARCH = "amd64" ]; then GOARCH=amd64 GOOS=linux ./build
+elif [ $PKGARCH = "i386" ]; then GOARCH=386 GOOS=linux ./build
+else
+  echo "Specify PKGARCH=amd64 or PKGARCH=i386"
+  exit -1
+fi
 
 echo "Building $PKGFILE"
 
@@ -23,7 +30,7 @@ mkdir -p /tmp/$PKGNAME/usr/bin/
 mkdir -p /tmp/$PKGNAME/etc/systemd/system/
 
 cat > /tmp/$PKGNAME/debian/changelog << EOF
-Insert changelog here
+Please see https://github.com/Arceliar/yggdrasil-go/
 EOF
 echo 9 > /tmp/$PKGNAME/debian/compat
 cat > /tmp/$PKGNAME/debian/control << EOF
@@ -32,15 +39,15 @@ Version: $PKGVERSION
 Section: contrib/net
 Priority: extra
 Architecture: $PKGARCH
-Maintainer: Neil Alexander <neilalexander@noreply.users.github.com>
+Maintainer: Neil Alexander <neilalexander@users.noreply.github.com>
 Description: Debian yggdrasil package
  Binary yggdrasil package for Debian and Ubuntu
 EOF
 cat > /tmp/$PKGNAME/debian/copyright << EOF
-Insert copyright notice here
+Please see https://github.com/Arceliar/yggdrasil-go/
 EOF
 cat > /tmp/$PKGNAME/debian/docs << EOF
-Insert docs here
+Please see https://github.com/Arceliar/yggdrasil-go/
 EOF
 cat > /tmp/$PKGNAME/debian/install << EOF
 usr/bin/yggdrasil usr/bin
@@ -56,9 +63,6 @@ cat > /tmp/$PKGNAME/debian/prerm << EOF
 systemctl disable yggdrasil
 systemctl stop yggdrasil
 EOF
-
-if [ $PKGARCH = "amd64" ]; then GOARCH=amd64 GOOS=linux ./build; fi
-if [ $PKGARCH = "i386" ]; then GOARCH=386 GOOS=linux ./build; fi
 
 cp yggdrasil /tmp/$PKGNAME/usr/bin/
 cp contrib/systemd/yggdrasil.service /tmp/$PKGNAME/etc/systemd/system/

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+# This is a lazy script to create a .deb for Debian/Ubuntu. It installs
+# yggdrasil and enables it in systemd. You can give it the PKGARCH= argument
+# i.e. PKGARCH=i386 sh contrib/deb/generate.sh
+
+if [ `pwd` != `git rev-parse --show-toplevel` ]
+then
+  echo "You should run this script from the top-level directory of the git repo"
+  exit -1
+fi
+
+PKGNAME=debian-yggdrasil
+PKGARCH=${PKGARCH-amd64}
+PKGVERSION=0.$(git rev-list HEAD --count 2>/dev/null | xargs printf "%04d")
+PKGFILE=$PKGNAME-$PKGVERSION-$PKGARCH.deb
+
+echo "Building $PKGFILE"
+
+mkdir -p /tmp/$PKGNAME/
+mkdir -p /tmp/$PKGNAME/debian/
+mkdir -p /tmp/$PKGNAME/usr/bin/
+mkdir -p /tmp/$PKGNAME/etc/systemd/system/
+
+cat > /tmp/$PKGNAME/debian/changelog << EOF
+Insert changelog here
+EOF
+echo 9 > /tmp/$PKGNAME/debian/compat
+cat > /tmp/$PKGNAME/debian/control << EOF
+Package: $PKGNAME
+Version: $PKGVERSION
+Section: contrib/net
+Priority: extra
+Architecture: $PKGARCH
+Maintainer: Neil Alexander <neilalexander@noreply.users.github.com>
+Description: Debian yggdrasil package
+ Binary yggdrasil package for Debian and Ubuntu
+EOF
+cat > /tmp/$PKGNAME/debian/copyright << EOF
+Insert copyright notice here
+EOF
+cat > /tmp/$PKGNAME/debian/docs << EOF
+Insert docs here
+EOF
+cat > /tmp/$PKGNAME/debian/install << EOF
+usr/bin/yggdrasil usr/bin
+etc/systemd/system/*.service etc/systemd/system
+EOF
+cat > /tmp/$PKGNAME/debian/postinst << EOF
+#!/bin/sh
+systemctl enable yggdrasil
+systemctl start yggdrasil
+EOF
+cat > /tmp/$PKGNAME/debian/prerm << EOF
+#!/bin/sh
+systemctl disable yggdrasil
+systemctl stop yggdrasil
+EOF
+
+GOOS=linux GOARCH=$PKGARCH ./build
+
+cp yggdrasil /tmp/$PKGNAME/usr/bin/
+cp contrib/systemd/yggdrasil.service /tmp/$PKGNAME/etc/systemd/system/
+cp contrib/systemd/yggdrasil-resume.service /tmp/$PKGNAME/etc/systemd/system/
+
+tar -czvf /tmp/$PKGNAME/data.tar.gz -C /tmp/$PKGNAME/ \
+  usr/bin/yggdrasil \
+  etc/systemd/system/yggdrasil.service \
+  etc/systemd/system/yggdrasil-resume.service
+tar -czvf /tmp/$PKGNAME/control.tar.gz -C /tmp/$PKGNAME/debian .
+echo 2.0 > /tmp/$PKGNAME/debian-binary
+
+ar -r $PKGFILE \
+  /tmp/$PKGNAME/debian-binary \
+  /tmp/$PKGNAME/control.tar.gz \
+  /tmp/$PKGNAME/data.tar.gz
+
+rm -rf /tmp/$PKGNAME
+

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -10,15 +10,19 @@ then
   exit -1
 fi
 
-PKGNAME=yggdrasil
+PKGBRANCH=$(basename `git name-rev --name-only HEAD`)
+if [ "$PKGBRANCH" = "master" ]; then PKGNAME=yggdrasil
+else PKGNAME=yggdrasil-${PKGBRANCH}; fi
 PKGARCH=${PKGARCH-amd64}
 PKGVERSION=0.$(git rev-list HEAD --count 2>/dev/null | xargs printf "%04d")
 PKGFILE=$PKGNAME-$PKGVERSION-$PKGARCH.deb
 
 if [ $PKGARCH = "amd64" ]; then GOARCH=amd64 GOOS=linux ./build
 elif [ $PKGARCH = "i386" ]; then GOARCH=386 GOOS=linux ./build
+elif [ $PKGARCH = "mipsel" ]; then GOARCH=mipsle GOOS=linux ./build
+elif [ $PKGARCH = "mips" ]; then GOARCH=mips64 GOOS=linux ./build
 else
-  echo "Specify PKGARCH=amd64 or PKGARCH=i386"
+  echo "Specify PKGARCH=amd64,i386,mips,mipsel"
   exit -1
 fi
 


### PR DESCRIPTION
This is to add a really simple script to generate a bare-bones `.deb` file for Debian or Ubuntu running on amd64 or i386. The package installs itself into systemd, enables and starts the service on installation. On uninstall, it disables and stops itself.

This is mostly just to make it easier to provide a binary to someone else to test.

To build:
```
PKGARCH=amd64 sh contrib/deb/generate.sh
PKGARCH=i386 sh contrib/deb/generate.sh
```

The resulting `.deb` files can then be taken to a Debian system and installed.