### PR TITLE
Nodrop

### DIFF
--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -170,11 +170,7 @@ func (r *router) sendPacket(bs []byte) {
 			// Don't continue - drop the packet
 			return
 		}
-		select {
-		case sinfo.send <- bs:
-		default:
-			util_putBytes(bs)
-		}
+		sinfo.send <- bs
 	}
 }
 
@@ -225,11 +221,7 @@ func (r *router) handleTraffic(packet []byte) {
 		return
 	}
 	//go func () { sinfo.recv<-&p }()
-	select {
-	case sinfo.recv <- &p:
-	default:
-		util_putBytes(p.payload)
-	}
+	sinfo.recv <- &p
 }
 
 func (r *router) handleProto(packet []byte) {

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -173,7 +173,7 @@ func (n *node) listen() {
 		saddr := addr.String()
 		//if _, isIn := n.peers[saddr]; isIn { continue }
 		//n.peers[saddr] = struct{}{}
-		n.core.DEBUG_addTCPConn(saddr) // FIXME? can result in 2 connections per peer
+		n.core.DEBUG_addTCPConn(saddr)
 		//fmt.Println("DEBUG:", "added multicast peer:", saddr)
 	}
 }


### PR DESCRIPTION
Minor but important change.

There is a per-session crypto worker. Up until now, when the router tries to send a packet to a worker to be encrypted or decrypted, it has used a non-blocking channel send. If the channel blocks, it would immediately drop the packet. This would allow, for example, a TCP connection to keep pushing packets into the tun/tap, and they would drop before being encrypted or sent over the wire.

This change causes the channel send to crypto workers to block. This slows down the tun/tap reader and prevents connections from flooding traffic that immediately gets dropped. It significantly improves performance for some work loads that are sensitive to packet loss but apparently don't throttle back when it occurs, such as UDP-connected OpenVPN. It potentially reduces the benefit of multiple crypto workers, since the router can be blocked waiting for one crypto worker to be ready, while there are packets waiting in the tun/tap meant for another crypto session.

I'm pretty sure it's safe, *if and only if* `peer.out` calls are guaranteed to be non-blocking, which is true for the current implementation of the UDP, TCP, and simulation channel-based interfaces, with the exception of the self interface (which is a special case, and I think I've convinced myself is OK). If those constraints are violated, then it would be possible for a cycle of goroutines to deadlock while all trying to send to eachother, so it's extremely important that all network interface implementations going forward continue to provide non-blocking functions for `peer.out`.